### PR TITLE
[Node20] support newer versions of node and ESM

### DIFF
--- a/.github/workflows/test-flow.yml
+++ b/.github/workflows/test-flow.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [20.x, 22.x, 24.x] # only LTS versions
 
     steps:
     - uses: actions/checkout@v2

--- a/cli.js
+++ b/cli.js
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
-const { resolve } = require('path')
-const { Command } = require('commander');
-const getHandlers = require('./index')
-const pojoStick = require('pojo-stick')
-const pkg = require('./package.json')
+import { resolve } from 'path';
+import { Command } from 'commander';
+import getHandlers from './index.js';
+import pojoStick from 'pojo-stick';
+import { readFile } from 'fs/promises';
+
+const pkg = JSON.parse(
+  await readFile(new URL('./package.json', import.meta.url))
+);
 
 ;(async () => {
   // persistent appData

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-const chalk = require('chalk');
-const { confirm, checkbox, text, select, number, password } = require('./lib/inputs')
+import chalk from 'chalk';
+import { confirm, checkbox, text, select, number, password } from './lib/inputs.js';
 
-module.exports = function getHandlers ({ appData }) {
+export default function getHandlers({ appData }) {
   
   async function test (action, type, rest) {
     appData.test = appData.test || { timesCalled: 0, lastCalledArgs: {} }

--- a/lib/inputs.js
+++ b/lib/inputs.js
@@ -1,4 +1,4 @@
-const inquirer = require('inquirer');
+import inquirer from 'inquirer';
 const base = inquirer.createPromptModule();
 
 const prompt = async ({ name = "__last_asked_question__", ...props } = {}) => {
@@ -24,21 +24,19 @@ const isNumber = (input) => {
   return true
 }
 
-module.exports = {
-  text: (message = '', options = {}) => prompt({ validate: notEmpty, ...options, type: 'input', message }),
-  number: async (message = '', options = {}) => {
-    const numText = await prompt({ validate: notEmpty, ...options, type: 'input', message, validate: isNumber })
-    return Number(numText)
-  },
-  password: (message = '', options = {}) => prompt({ validate: notEmpty, ...options, type: 'password', message }),
-  
-  checkbox: (label, choices = [], options = {}) => prompt({ validate: notEmpty, ...options, name: label, type: 'checkbox', choices }),
-  select: (label, choices = [], options = {}) => prompt({ validate: notEmpty, ...options, name: label, type: 'list', choices }),
-  
-  confirm: (message = '', defOption = false, options = {}) => prompt({ validate: notEmpty, ...options, default: defOption, type: 'confirm', message }),
+export const text = (message = '', options = {}) => prompt({ validate: notEmpty, ...options, type: 'input', message });
+export const number = async (message = '', options = {}) => {
+  const numText = await prompt({ validate: notEmpty, ...options, type: 'input', message, validate: isNumber })
+  return Number(numText)
+};
+export const password = (message = '', options = {}) => prompt({ validate: notEmpty, ...options, type: 'password', message });
 
-  validate: {
-    isNumber,
-    notEmpty,
-  }
-}
+export const checkbox = (label, choices = [], options = {}) => prompt({ validate: notEmpty, ...options, name: label, type: 'checkbox', choices });
+export const select = (label, choices = [], options = {}) => prompt({ validate: notEmpty, ...options, name: label, type: 'list', choices });
+
+export const confirm = (message = '', defOption = false, options = {}) => prompt({ validate: notEmpty, ...options, default: defOption, type: 'confirm', message });
+
+export const validate = {
+  isNumber,
+  notEmpty,
+};

--- a/package.json
+++ b/package.json
@@ -3,15 +3,19 @@
   "version": "0.1.0",
   "description": "__REPLACE_DESCRIPTION_WITH_MAKE_CMD__",
   "main": "cli.js",
+  "type": "module",
   "repository": "https://github.com/kyle-west/__REPLACE_PACKAGE_NAME_WITH_MAKE_CMD__",
   "author": "kyle-west",
   "license": "UNLICENSED",
   "private": true,
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "dependencies": {
-    "chalk": "^4.1.0",
-    "commander": "^6.1.0",
-    "inquirer": "^7.3.3",
-    "jest": "^26.6.3",
+    "chalk": "^5.4.1",
+    "commander": "^14.0.0",
+    "inquirer": "^12.6.3",
+    "jest": "^29.7.0",
     "pojo-stick": "^0.1.0"
   },
   "bin": {

--- a/test.js
+++ b/test.js
@@ -1,1 +1,3 @@
-test.todo('write tests')
+// Using ESM syntax, if this file needs proper test imports later
+// For now, just keeping the todo comment
+test.todo('write tests');


### PR DESCRIPTION
This hadn't been touched since April of 2021, and it's 2025 and I want to make some CLI's again, so I needed to update this template first.

- Support Node20 and above LTS versions
- update to use ECMAScript Modules
- update deps to use the latest version as of today.